### PR TITLE
Patch All Links If There Are Multiple "New Pull Request" Links

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,40 +20,43 @@
     }
 
     function patchNewPullRequestRedirect() {
-        // Find the "New pull request" button
-        const newPullRequestButton = document.querySelector('a[href*="/compare"]')
-        if (!newPullRequestButton) {
+        // Find all "New pull request" buttons
+        const newPullRequestButtons = document.querySelectorAll('a[href*="/compare"]')
+        if (newPullRequestButtons.length === 0) {
             return
         }
 
-        if (isAlReadyPatched(newPullRequestButton.href)) {
-            return
-        }
-
-        // Check if the button exists
+        // Get repo information from current URL
         const currentHref = window.location.href
         //e.g. https://github.com/icefoganalytics/travel-authorization/compare
         const urlSegments = currentHref.split("/")
         const repoOwner = urlSegments[3]
         const repoName = urlSegments[4]
 
-        // Change the button's href attribute to the desired URL
-        // Check if the URL includes a specific branch
-        // e.g. https://github.com/icefoganalytics/travel-authorization/compare/issue-119/implement-correcting-lines-for-non-travel-status-days-on-estimate-tab?expand=1
-        const buttonHref = newPullRequestButton.href
-        if (buttonHref.includes("/compare/")) {
-            const [urlPart, queryParams] = buttonHref.split("?")
-            const [_repoPath, branchName] = urlPart.split("/compare/", 7)
+        // Patch each button
+        newPullRequestButtons.forEach((newPullRequestButton) => {
+            if (isAlReadyPatched(newPullRequestButton.href)) {
+                return
+            }
 
-            // Adjust the button's href for the specific branch
-            // e.g. https://github.com/icefoganalytics/travel-authorization/compare/main...icefoganalytics:travel-authorization:issue-119/implement-correcting-lines-for-non-travel-status-days-on-estimate-tab?expand=1
-            newPullRequestButton.href = `/${repoOwner}/${repoName}/compare/main...${repoOwner}:${repoName}:${branchName}?${queryParams}`
-        } else {
-            // Default behavior for the main branch
-            // e.g. /icefoganalytics/travel-authorization/compare/main...icefoganalytics:travel-authorization:main
-            newPullRequestButton.href = `/${repoOwner}/${repoName}/compare/main...${repoOwner}:${repoName}:main`
-        }
-        // console.log("newPullRequestButton.href", newPullRequestButton.href)
+            // Change the button's href attribute to the desired URL
+            // Check if the URL includes a specific branch
+            // e.g. https://github.com/icefoganalytics/travel-authorization/compare/issue-119/implement-correcting-lines-for-non-travel-status-days-on-estimate-tab?expand=1
+            const buttonHref = newPullRequestButton.href
+            if (buttonHref.includes("/compare/")) {
+                const [urlPart, queryParams] = buttonHref.split("?")
+                const [_repoPath, branchName] = urlPart.split("/compare/", 7)
+
+                // Adjust the button's href for the specific branch
+                // e.g. https://github.com/icefoganalytics/travel-authorization/compare/main...icefoganalytics:travel-authorization:issue-119/implement-correcting-lines-for-non-travel-status-days-on-estimate-tab?expand=1
+                newPullRequestButton.href = `/${repoOwner}/${repoName}/compare/main...${repoOwner}:${repoName}:${branchName}?${queryParams}`
+            } else {
+                // Default behavior for the main branch
+                // e.g. /icefoganalytics/travel-authorization/compare/main...icefoganalytics:travel-authorization:main
+                newPullRequestButton.href = `/${repoOwner}/${repoName}/compare/main...${repoOwner}:${repoName}:main`
+            }
+            // console.log("newPullRequestButton.href", newPullRequestButton.href)
+        })
     }
 
     // Run the function immediately on page load for existing elements

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -45,5 +45,30 @@ describe("main.js", () => {
                 "https://github.com/icefoganalytics/travel-authorization/compare/main...icefoganalytics:travel-authorization:issue-36/part-6/build-and-or-normalize-workflow-step-players-back-end?expand=1"
             )
         })
+
+        test("when multiple PR links are present on the page, patches all of them", () => {
+            // Arrange
+            document.body.innerHTML = `
+                <a href="https://github.com/icefoganalytics/travel-authorization/compare"></a>
+                <a href="https://github.com/icefoganalytics/travel-authorization/compare/feature-branch?expand=1"></a>
+                <a href="https://github.com/icefoganalytics/travel-authorization/compare/another-feature?expand=1"></a>
+            `
+
+            // Act
+            require("../main.js")
+
+            // Assert
+            const links = document.querySelectorAll('a[href*="/compare"]')
+            expect(links.length).toBe(3)
+            expect(links[0].href).toBe(
+                "https://github.com/icefoganalytics/travel-authorization/compare/main...icefoganalytics:travel-authorization:main"
+            )
+            expect(links[1].href).toBe(
+                "https://github.com/icefoganalytics/travel-authorization/compare/main...icefoganalytics:travel-authorization:feature-branch?expand=1"
+            )
+            expect(links[2].href).toBe(
+                "https://github.com/icefoganalytics/travel-authorization/compare/main...icefoganalytics:travel-authorization:another-feature?expand=1"
+            )
+        })
     })
 })


### PR DESCRIPTION
The script was using querySelector which only selected the first PR link. When multiple "New Pull Request" links were present on a GitHub page, only the first one would be patched.

Changes:
- Updated patchNewPullRequestRedirect() to use querySelectorAll
- Added forEach loop to patch all matching PR links
- Added test case to verify multiple PR links are all patched correctly

Fixes #1